### PR TITLE
Allow decimal input within NumberInput

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -69,6 +69,11 @@ impl Input for NumberInput {
             event::Key::Char('-') => {
                 self.display_string.replace_range(..1, "-");
             },
+            event::Key::Char('.') => {
+                if !self.display_string.contains(".") {
+                    self.display_string.push('.');
+                }
+            },
             _ => (),
         };
         self.number_value = self.display_string.parse().unwrap();


### PR DESCRIPTION
Fixes #14 
Catches `.` character entry, checks if display string already has one and appends `.` to display string if not.