### PR TITLE
Set minimum height for top row in view.

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -170,7 +170,7 @@ impl Application {
         Group::default()
             .direction(Direction::Vertical)
             .margin(1)
-            .sizes(&[Size::Min(3), Size::Percent(97)])
+            .sizes(&[Size::Min(3), Size::Percent(100)])
             .render(t, size, |t, chunks| {
                 Group::default()
                     .direction(Direction::Horizontal)

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -170,7 +170,7 @@ impl Application {
         Group::default()
             .direction(Direction::Vertical)
             .margin(1)
-            .sizes(&[Size::Percent(10), Size::Percent(90)])
+            .sizes(&[Size::Min(3), Size::Percent(97)])
             .render(t, size, |t, chunks| {
                 Group::default()
                     .direction(Direction::Horizontal)


### PR DESCRIPTION
Addresses #13.

I don't believe the value that Size::Min takes is based off any percentage, but the combination of Min(3) and Percent(97) seems to work well after playing around with it. I can tweak the values a bit more if desired.

Some images (Before/After):
![First](https://imgur.com/cWVoyjy.png)
![Second](https://imgur.com/37ICetc.png)
![Third](https://imgur.com/jaGtsYH.png)
