### PR TITLE
Better Error Checking

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -270,7 +270,9 @@ impl Application {
             // TODO: Handle plotting errors and display error messages.
             match self.plot_function() {
                 Ok(vec) => {
-                    self.evaluation = vec;
+                    // Filters all instances of f64::NAN from the vector
+                    self.evaluation = vec.into_iter()
+                        .filter(|&(_,a)| a.is_normal()).collect();
                     let (start_y, end_y) = determine_y_bounds(&self.evaluation);
                     self.start_y = start_y;
                     self.end_y = end_y;


### PR DESCRIPTION
This is a much simpler solution, also prevents the bug where the program would crash if a user typed ln(0) and prevents any specific case handling as NAN is already built into f64::NAN and this simply filters NAN values from the vector of pixel coords.