### PR TITLE
add N-ary expressions and log

### DIFF
--- a/src/expression.rs
+++ b/src/expression.rs
@@ -75,6 +75,7 @@ pub enum ExpressionNode {
 #[derive(Debug)]
 pub enum EvaluationError {
     VariableNotFoundError,
+    WrongNumberOfArgsError,
 }
 
 impl ExpressionNode {
@@ -123,7 +124,10 @@ impl ExpressionNode {
                     child_values.push(node.evaluate(&vars)?);
                 }
                 match operator {
-                    NaryOperator::Log => Ok(child_values[0].log(child_values[1])),
+                    NaryOperator::Log => match child_values.len() {
+                        2 => Ok(child_values[0].log(child_values[1])),
+                        _ => Err(EvaluationError::WrongNumberOfArgsError),
+                    }
                 }
             }
             ExpressionNode::VariableExprNode { variable_key } => match vars.get(variable_key) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -515,8 +515,14 @@ fn test_parse_term() {
         3.0,
     );
 
+    let x = parse_expr(CompleteStr("log(3,9,5)")).unwrap().1.evaluate(&vars_map);
+    let _test_err = match x {
+        Err(EvaluationError::WrongNumberOfArgsError) => "discard",
+        e => panic!("expected WrongNumberOfArgsError, found {:?}", e),
+    };
+
     assert_eq!(
-        parse_expr(CompleteStr("log(3,9)"))
+        parse_expr(CompleteStr("log(9,3)"))
             .unwrap()
             .1
             .evaluate(&vars_map)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -132,6 +132,21 @@ named!(parse_exp<CompleteStr, ExpressionNode>,
     )
 );
 
+named!(parse_args<CompleteStr, Vec<ExpressionNode>>,
+    delimited!( char!('('), separated_list!(tag!(","), parse_expr), char!(')') )
+);
+
+named!(parse_log<CompleteStr, ExpressionNode>,
+    do_parse!(
+        tag!("log") >>
+        res: parse_args >>
+        (ExpressionNode::NaryExprNode {
+            operator: NaryOperator::Log,
+            child_nodes: Box::new(res),
+        })
+    )
+);
+
 named!(pub parse_expr<CompleteStr, ExpressionNode>,
     call!(parse_priority_4)
 );
@@ -147,6 +162,7 @@ named!(parse_priority_0<CompleteStr, ExpressionNode>,
         parse_log2       |
         parse_ln         |
         parse_exp        |
+        parse_log        |
         parse_variable
     )
 );
@@ -497,6 +513,15 @@ fn test_parse_term() {
             .evaluate(&vars_map)
             .unwrap(),
         3.0,
+    );
+
+    assert_eq!(
+        parse_expr(CompleteStr("log(3,9)"))
+            .unwrap()
+            .1
+            .evaluate(&vars_map)
+            .unwrap(),
+        2.0,
     );
 
     assert_eq!(


### PR DESCRIPTION
This aims to resolve #21.

Tasks as taken from the issue:
- [x] add log function to the expression evaluator
- [x] add support for parsing non-unary functions in general
- [x] add support for parsing log as a non-unary function

Currently, `log(2, x)` is not parsed correctly(see the whitespace) but I did not implement since `2 + 2` isn't parsed either.