### PR TITLE
Resolve #29

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -273,8 +273,14 @@ impl Application {
                         .filter(|&(_,a)| a.is_normal()).collect();
                     let (start_y, end_y) =
                         determine_y_bounds(&self.evaluation).unwrap_or((0.0, 0.0));
-                    self.start_y = start_y;
-                    self.end_y = end_y;
+                    if start_y == end_y {
+                        let end_y_abs = end_y.abs();
+                        self.start_y = -end_y_abs;
+                        self.end_y = end_y_abs;
+                    } else {
+                        self.start_y = start_y;
+                        self.end_y = end_y;
+                    }
                 },
                 Err(_) => {
                     self.evaluation = Vec::new();

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -100,14 +100,12 @@ enum ApplicationOperation {
     Noop,
 }
 
-fn determine_y_bounds(vec: &Vec<(f64, f64)>) -> (f64, f64) {
-    let mut current_min = 0.0;
-    let mut current_max = 0.0;
-    for (_, y) in vec {
-        current_min = if *y < current_min { *y } else { current_min };
-        current_max = if *y > current_max { *y } else { current_max };
-    }
-    (current_min, current_max)
+fn determine_y_bounds(vec: &Vec<(f64, f64)>) -> Option<(f64, f64)> {
+    vec.into_iter().fold(None, |acc, &(_, y)| {
+        Some(acc.map_or((y, y), |(acc_min, acc_max)| {
+            (y.min(acc_min), y.max(acc_max))
+        }))
+    })
 }
 
 enum Error {
@@ -273,7 +271,8 @@ impl Application {
                     // Filters all instances of f64::NAN from the vector
                     self.evaluation = vec.into_iter()
                         .filter(|&(_,a)| a.is_normal()).collect();
-                    let (start_y, end_y) = determine_y_bounds(&self.evaluation);
+                    let (start_y, end_y) =
+                        determine_y_bounds(&self.evaluation).unwrap_or((0.0, 0.0));
                     self.start_y = start_y;
                     self.end_y = end_y;
                 },


### PR DESCRIPTION
As you can see, I have changed the return type of `determine_y_bounds` (and updated its body accordingly). 😄 

Here’s the catch: Using `determine_y_bounds(…).unwrap_or((0.0, 0.0))` at the call site does not prevent the program panics I’ve mentioned in the last paragraph of [my previous comment][1]. If you put a constant function, say “5”, in the function box, the program crashes. What happens is that `determine_y_bounds` correctly returns `Some(5.0, 5.0)`. And this later on causes the program to panic at `…/tui-rs-7b8c262bc963a224/d5408ae/src/widgets/canvas/mod.rs:104:25`.

Using the following code at the call site restores the original behaviour (i.e. no panics) but also reintroduces the original issue. 😅

```rust
let (start_y, end_y) =
    determine_y_bounds(&self.evaluation).unwrap_or((0.0, 0.0));
self.start_y = start_y.min(0.0);
self.end_y   = end_y.max(0.0);
```

[1]: https://github.com/z2oh/sexe/issues/29#issuecomment-432134524