### PR TITLE
Focus support

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -179,11 +179,13 @@ impl Application {
             event::Key::Esc => {
                 self.focused = false;
             },
-            // Otherwise we modify focus and hand off input to the children.
+            // Otherwise we potentially modify focus and hand off input to the children.
             _ => {
-                self.focused = true;
                 match self.selected_box {
-                SelectedBox::Function => self.function_input.process_input(&key),
+                SelectedBox::Function => {
+                    self.focused = true;
+                    self.function_input.process_input(&key)
+                },
                 SelectedBox::StartX => self.start_x_input.process_input(&key),
                 SelectedBox::EndX => self.end_x_input.process_input(&key),
             }},


### PR DESCRIPTION
This PR addresses the issue of not being able to focus and in-point modify the function text.
Previously, this was an issue if you had large complicated functions that needed changes as text was simply appended to the end of the expression and there was no way to change text in the middle, for instance.

This PR allows for in-point modification and adds a rudimentary cursor. I believe Termion has support for a blinking cursor, but I did not get around to implementing it. Feel free.