### PR TITLE
Benchmarking (also rudimentary cursor implementation)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Jeremy Day <jadaytime@gmail.com>"]
 nom     = "^4.1"
 termion = "^1.5"
 
+
 [dependencies.tui]
 git = "https://github.com/z2oh/tui-rs/"
 rev = "d5408ae193f948bdf1e7f981e697c0b33011ebfc"

--- a/README.MD
+++ b/README.MD
@@ -1,4 +1,5 @@
 # (s)imple (ex)pression (e)valuator
+
 [![Build Status](https://travis-ci.org/z2oh/sexe.svg?branch=master)](https://travis-ci.org/z2oh/sexe)
 
 <center>
@@ -24,3 +25,22 @@ cargo build --release
 ```
 
 The binary is then located at `./target/release/sexe`.
+
+## Benchmarking statistics
+
+Running the command `rustup run nightly cargo bench` will result in some generic benchmarks for function evaluation.
+
+Below are some results for certain expressions:
+
+```
+test interface::tests::complicated_expression_100res    ... bench:      67,226 ns/iter (+/- 19,984)
+test interface::tests::complicated_expression_amillires ... bench: 327,308,599 ns/iter (+/- 4,189,208)
+test interface::tests::sine_expression_100res           ... bench:      11,714 ns/iter (+/- 1,650)
+test interface::tests::sine_expression_amillires        ... bench:  80,355,897 ns/iter (+/- 8,516,084)
+test interface::tests::single_variable_100res           ... bench:       8,075 ns/iter (+/- 1,122)
+test interface::tests::single_variable_amillires        ... bench:  62,609,645 ns/iter (+/- 4,351,933)
+```
+
+Where the complicated_expression is `|sin(x^x) / 2^((x^x - pi/2)/pi)|`
+
+As you can see, this complicated expression evaluated at a resolution of 1,000,000 only took 0.327 seconds to evaluate. That's pretty fast!

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -174,4 +174,6 @@ mod tests {
 
         assert_eq!(complex_expression.evaluate(&vars_map).unwrap(), 12.0);
     }
+
+
 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -398,4 +398,53 @@ pub fn display() {
     };
     application.start();
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    extern crate test;
+    use self::test::Bencher;
 
+    #[bench]
+    fn single_variable_100res(b: &mut Bencher) {
+        b.iter(|| {
+            evaluate_function_over_domain(0.0f64, 10.0f64, 100, "x")
+        });
+    }
+
+    #[bench]
+    fn sine_expression_100res(b: &mut Bencher) {
+        b.iter(|| {
+            evaluate_function_over_domain(0.0f64, 10.0f64, 100, "sin(x)")
+        });
+    }
+
+    #[bench]
+    fn complicated_expression_100res(b: &mut Bencher) {
+        b.iter(|| {
+            evaluate_function_over_domain(0.0f64, 10.0f64, 100, "|sin(x^x) / 2^((x^x - pi/2)/pi)|")
+        });
+    }
+
+    #[bench]
+    fn single_variable_amillires(b: &mut Bencher) {
+        b.iter(|| {
+            evaluate_function_over_domain(0.0f64, 10.0f64, 1000000, "x")
+        });
+    }
+
+    #[bench]
+    fn sine_expression_amillires(b: &mut Bencher) {
+        b.iter(|| {
+            evaluate_function_over_domain(0.0f64, 10.0f64, 1000000, "sin(x)")
+        });
+    }
+
+    #[bench]
+    fn complicated_expression_amillires(b: &mut Bencher) {
+        b.iter(|| {
+            evaluate_function_over_domain(0.0f64, 10.0f64, 1000000, "|sin(x^x) / 2^((x^x - pi/2)/pi)|")
+        });
+    }
+
+
+}

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -179,11 +179,13 @@ impl Application {
             event::Key::Esc => {
                 self.focused = false;
             },
-            // Otherwise we modify focus and hand off input to the children.
+            // Otherwise we potentially modify focus and hand off input to the children.
             _ => {
-                self.focused = true;
                 match self.selected_box {
-                SelectedBox::Function => self.function_input.process_input(&key),
+                SelectedBox::Function => {
+                    self.focused = true;
+                    self.function_input.process_input(&key)
+                },
                 SelectedBox::StartX => self.start_x_input.process_input(&key),
                 SelectedBox::EndX => self.end_x_input.process_input(&key),
             }},

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![feature(test)]
 #[macro_use]
 extern crate nom;
 extern crate termion;
@@ -8,6 +9,7 @@ use std::io;
 mod expression;
 mod parser;
 mod interface;
+
 
 fn main() {
     let should_display_interface = true;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -451,4 +451,5 @@ mod test {
         error_test!("log(3,    9   ,5)", EvaluationError::WrongNumberOfArgsError);
         error_test!("y", EvaluationError::VariableNotFoundError, &vars_map);
     }
+
 }


### PR DESCRIPTION
This PR adds benchmarking to sexe and also implements a rudimentary cursor implementation.
(I hadn't seen @GooseDB 's cursor implementation before doing my own. Mine will likely be overridden, which is totally okay)
Small note on the cursor implementation: press any key when selecting the function box to focus into it, then press Escape to unfocus. 

To test the benchmark on your computer, you can run `rustup install nightly` to install the nightly Rust toolchain, then run the command `rustup run nightly cargo bench` to view the results.

The README contains more information, and a preview of the benchmarking.